### PR TITLE
run mqtt-robot-webdriver on Raspberry Pi (nginx + gunicorn)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
 # webdriver
 
-How to start:
+## Requirements
+
+On Debian/Ubuntu install python libraries:
+```bash
+sudo apt-get install python-configparser python-flask python-paho-mqtt
+```
+
+## Configuration
+
+Edit `driver.ini` and configure your MQTT server (default is broker.hivemq.com)
+
+## How to start:
 
  * set-up mqtt broker (or use public)
 

--- a/driver.ini
+++ b/driver.ini
@@ -1,3 +1,7 @@
+[webdriver]
+listen = 127.0.0.1
+port = 5000
+
 [mqtt-server]
 host = broker.hivemq.com
 ; check status http://www.mqtt-dashboard.com/

--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+
 import webdriver
 
 webdriver.app.run()

--- a/main.py
+++ b/main.py
@@ -1,5 +1,15 @@
 #!/usr/bin/python
 
 import webdriver
+import configparser
 
-webdriver.app.run()
+CONFIG_FNAME = 'driver.ini'
+
+config = configparser.ConfigParser()
+config.read([CONFIG_FNAME])
+
+#webdriver.app.debug = True
+webdriver.app.run(
+        host = config['webdriver']['listen'],
+        port = config['webdriver']['port']
+        )

--- a/robots.py
+++ b/robots.py
@@ -24,7 +24,7 @@ class RobotGroup:
             mqtt_client.username_pw_set(mqtt_config['username'],
                                         mqtt_config['password'])
         mqtt_client.connect(host=mqtt_config['host'])
-        logger.info("MQTT connecting to %s", mqtt_config['host'])
+        logger.info("MQTT connecting to '%s'", mqtt_config['host'])
         mqtt_client.subscribe('/robot/+/$online$')
         mqtt_client.subscribe('/robot/+/$name$')
 

--- a/webdriver.py
+++ b/webdriver.py
@@ -43,6 +43,11 @@ def robot_list():
     global robot_group
     return render_template('index.html', robots=robot_group.robot_list())
 
+@app.route('/robot/')
+def catch_all():
+    global robot_group
+    return render_template('index.html', robots=robot_group.robot_list())
+
 @app.route('/robot/<robot_id>/', methods=['GET', 'POST'])
 def robot_page(robot_id):
     global robot_group

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,0 +1,15 @@
+#!/usr/bin/python
+
+#
+# gunicorn WSGI Entry Point
+#
+# To run this application as www-data on Raspberry Pi
+# create systemd service.
+# See https://github.com/lhost/rpi-scripts/blob/master/nodemcu-webdriver.sh for example
+
+from webdriver import app
+
+application = app
+
+if __name__ == "__main__":
+    application.run()


### PR DESCRIPTION
- added configurable listening IP and port for this web application
- added ability to run under gunicorn webserver
- URL /robot/ is routed to robot_list(), which allows to run application behind nginx proxy (see https://github.com/lhost/rpi-scripts/blob/8052cf3/nodemcu-webdriver.sh#L129)